### PR TITLE
Feature/deny duplicate names

### DIFF
--- a/WebFileSystem.ts
+++ b/WebFileSystem.ts
@@ -480,10 +480,16 @@ class WebFileSystem extends webdav.FileSystem {
      */
     async createResource (path: Path, user: User, type: webdav.ResourceType) : Promise<Error> {
         // TODO: Handle permissions
+
+        // checks if file already exists and if filename contains bad characters (e.g. "§%?&....")
         if (this.resources.get(user.uid).has(path.toString())) {
             logger.info(`Resource ${path} already exists.`)            
             return webdav.Errors.ResourceAlreadyExists
+        } else if (path.fileName() !== encodeURI(path.fileName())){
+            logger.info(`Resourcename ${path.fileName()} not allowed.`)
+            return new Error('The Name of the Resource contains forbidden characters')
         }
+
         if (type.isDirectory || mime.extension(mime.lookup(path.fileName())) in ['docx', 'pptx', 'xlsx']) {
             let owner
             let parent

--- a/WebFileSystem.ts
+++ b/WebFileSystem.ts
@@ -487,7 +487,7 @@ class WebFileSystem extends webdav.FileSystem {
             return webdav.Errors.ResourceAlreadyExists
         } else if (path.fileName().match(/[!@#$%^&*()\[\]\+=,<>\?\/\|~{}]+/)){
             logger.info(`Resourcename ${path.fileName()} not allowed.`)
-            return new Error('The Name of the Resource contains forbidden characters')
+            return webdav.Errors.IllegalArguments
         }
 
         if (type.isDirectory || mime.extension(mime.lookup(path.fileName())) in ['docx', 'pptx', 'xlsx']) {

--- a/WebFileSystem.ts
+++ b/WebFileSystem.ts
@@ -585,7 +585,7 @@ class WebFileSystem extends webdav.FileSystem {
         if (this.resourceExists(path, user)) {
             logger.info(`Resource ${path} already exists.`)
             return webdav.Errors.ResourceAlreadyExists
-        } else if (path.fileName().match(/[!@#$%^&*()\[\]\+=,<>\?\/\|~{}]+/)){
+        } else if (path.fileName().match(/[!@#$%^&*()[\]+=,<>?/|~{}]+/)){
             logger.info(`Resourcename ${path.fileName()} not allowed.`)
             return webdav.Errors.IllegalArguments
         }

--- a/WebFileSystem.ts
+++ b/WebFileSystem.ts
@@ -485,7 +485,7 @@ class WebFileSystem extends webdav.FileSystem {
         if (this.resources.get(user.uid).has(path.toString())) {
             logger.info(`Resource ${path} already exists.`)            
             return webdav.Errors.ResourceAlreadyExists
-        } else if (path.fileName() !== encodeURI(path.fileName())){
+        } else if (!path.fileName().match(/^[^!@#$%^&*()\[\]\+=,<>\?\/\|~{}]*$/)){
             logger.info(`Resourcename ${path.fileName()} not allowed.`)
             return new Error('The Name of the Resource contains forbidden characters')
         }

--- a/WebFileSystem.ts
+++ b/WebFileSystem.ts
@@ -167,6 +167,17 @@ class WebFileSystem extends webdav.FileSystem {
     }
 
     /*
+     * Returns true if the filename is valid
+     *
+     * @param {string} name   Name of the file
+     *
+     * @return {Boolean}    true if fileName is valid, false else
+     */
+    validFileName(name: string): Boolean{
+        if(name.match(/[#%^[\],<>?/|~{}]+/)){return false}
+        return true
+    }
+    /*
      * Loads the root directories of the user
      *
      * @param {User} user   Current user
@@ -585,7 +596,7 @@ class WebFileSystem extends webdav.FileSystem {
         if (this.resourceExists(path, user)) {
             logger.info(`Resource ${path} already exists.`)
             return webdav.Errors.ResourceAlreadyExists
-        } else if (path.fileName().match(/[#%^[\],<>?/|~{}]+/)){
+        } else if (!this.validFileName(path.fileName())){
             logger.info(`Resourcename ${path.fileName()} not allowed.`)
             return webdav.Errors.Forbidden
         }
@@ -928,7 +939,10 @@ class WebFileSystem extends webdav.FileSystem {
         if (this.resources.get(user.uid).get(path.toString()).permissions.write) {
 
             // TODO: Check new name for unallowed characters (for example question mark)
-
+            if(!this.validFileName(newName)){
+                logger.warn(`Resourcename: ${newName} not allowed.`)
+                return webdav.Errors.Forbidden
+            }
             const type: webdav.ResourceType = this.resources.get(user.uid).get(path.toString()).type
 
             return await api({user,json:true}).post('/fileStorage' + (type.isDirectory ? '/directories' : '') + '/rename', {

--- a/WebFileSystem.ts
+++ b/WebFileSystem.ts
@@ -587,7 +587,7 @@ class WebFileSystem extends webdav.FileSystem {
             return webdav.Errors.ResourceAlreadyExists
         } else if (path.fileName().match(/[#%^[\],<>?/|~{}]+/)){
             logger.info(`Resourcename ${path.fileName()} not allowed.`)
-            return webdav.Errors.IllegalArguments
+            return webdav.Errors.Forbidden
         }
 
         if (!this.resources.get(user.uid).get(path.getParent().toString()).permissions || this.resources.get(user.uid).get(path.getParent().toString()).permissions.create) {

--- a/WebFileSystem.ts
+++ b/WebFileSystem.ts
@@ -585,7 +585,7 @@ class WebFileSystem extends webdav.FileSystem {
         if (this.resourceExists(path, user)) {
             logger.info(`Resource ${path} already exists.`)
             return webdav.Errors.ResourceAlreadyExists
-        } else if (path.fileName().match(/[!@#$%^&*()[\]+=,<>?/|~{}]+/)){
+        } else if (path.fileName().match(/[#%^[\],<>?/|~{}]+/)){
             logger.info(`Resourcename ${path.fileName()} not allowed.`)
             return webdav.Errors.IllegalArguments
         }

--- a/WebFileSystem.ts
+++ b/WebFileSystem.ts
@@ -480,7 +480,10 @@ class WebFileSystem extends webdav.FileSystem {
      */
     async createResource (path: Path, user: User, type: webdav.ResourceType) : Promise<Error> {
         // TODO: Handle permissions
-
+        if (this.resources.get(user.uid).has(path.toString())) {
+            logger.info(`Resource ${path} already exists.`)            
+            return webdav.Errors.ResourceAlreadyExists
+        }
         if (type.isDirectory || mime.extension(mime.lookup(path.fileName())) in ['docx', 'pptx', 'xlsx']) {
             let owner
             let parent

--- a/WebFileSystem.ts
+++ b/WebFileSystem.ts
@@ -580,10 +580,10 @@ class WebFileSystem extends webdav.FileSystem {
      * @return {Promise<Error>}   Error or null depending on success of creation
      */
     async createResource (path: Path, user: User, type: webdav.ResourceType) : Promise<Error> {
-        
+
         // checks if file already exists and if filename contains bad characters (e.g. "§%?&....")
-        if (this.resources.get(user.uid).has(path.toString())) {
-            logger.info(`Resource ${path} already exists.`)            
+        if (this.resourceExists(path, user)) {
+            logger.info(`Resource ${path} already exists.`)
             return webdav.Errors.ResourceAlreadyExists
         } else if (path.fileName().match(/[!@#$%^&*()\[\]\+=,<>\?\/\|~{}]+/)){
             logger.info(`Resourcename ${path.fileName()} not allowed.`)

--- a/WebFileSystem.ts
+++ b/WebFileSystem.ts
@@ -485,7 +485,7 @@ class WebFileSystem extends webdav.FileSystem {
         if (this.resources.get(user.uid).has(path.toString())) {
             logger.info(`Resource ${path} already exists.`)            
             return webdav.Errors.ResourceAlreadyExists
-        } else if (!path.fileName().match(/^[^!@#$%^&*()\[\]\+=,<>\?\/\|~{}]*$/)){
+        } else if (path.fileName().match(/[!@#$%^&*()\[\]\+=,<>\?\/\|~{}]+/)){
             logger.info(`Resourcename ${path.fileName()} not allowed.`)
             return new Error('The Name of the Resource contains forbidden characters')
         }

--- a/WebFileSystem.ts
+++ b/WebFileSystem.ts
@@ -938,7 +938,6 @@ class WebFileSystem extends webdav.FileSystem {
     async renameResource (path: Path, user: User, newName: string) : Promise<Error> {
         if (this.resources.get(user.uid).get(path.toString()).permissions.write) {
 
-            // TODO: Check new name for unallowed characters (for example question mark)
             if(!this.validFileName(newName)){
                 logger.warn(`Resourcename: ${newName} not allowed.`)
                 return webdav.Errors.Forbidden


### PR DESCRIPTION
Having duplicate names of files is a problem in some WEBDAV browsers so it should atleast via webDav be forbidden to create such files.