### PR TITLE
Fix permission inconsistencies compared to SC-Client

### DIFF
--- a/User.ts
+++ b/User.ts
@@ -8,6 +8,7 @@ export default class User implements IUser {
     password: string;
     jwt: string;
     roles: Array<string>
+    permissions: Array<string>
 
     constructor(uid: string, username: string, password: string, jwt: string) {
         this.uid = uid
@@ -15,6 +16,7 @@ export default class User implements IUser {
         this.password = password
         this.jwt = jwt
         this.roles = []
+        this.permissions = []
     }
 
     /*
@@ -26,14 +28,16 @@ export default class User implements IUser {
 
         const res = await api({user : this}).get('/roles/user/' + this.uid);
 
-        // TODO: Store user permissions
-
         logger.info(res.data)
 
         for (const role of res.data) {
             this.roles.push(role.id)
-            const nestedRoles = role.roles
-            for (const nestedRole of nestedRoles) {
+            role.permissions.forEach((permission) => {
+                if (!this.permissions.includes(permission)) {
+                    this.permissions.push(permission)
+                }
+            })
+            for (const nestedRole of role.roles) {
                 this.roles.push(nestedRole)
                 await this.getNestedRoles(nestedRole)
             }
@@ -50,5 +54,11 @@ export default class User implements IUser {
             this.roles.push(role)
             await this.getNestedRoles(role)
         }
+
+        res.data.permissions.forEach((permission) => {
+            if (!this.permissions.includes(permission)) {
+                this.permissions.push(permission)
+            }
+        })
     }
 }

--- a/User.ts
+++ b/User.ts
@@ -28,7 +28,7 @@ export default class User implements IUser {
 
         const res = await api({user : this}).get('/roles/user/' + this.uid);
 
-        logger.info(res.data)
+        logger.debug(res.data)
 
         for (const role of res.data) {
             this.roles.push(role.id)

--- a/User.ts
+++ b/User.ts
@@ -25,6 +25,7 @@ export default class User implements IUser {
     async loadRoles() : Promise<void> {
 
         // TODO: Implement logic on SC-server instead of webdav with a specific flag
+
         const res = await api({user : this}).get('/roles/user/' + this.uid);
 
         logger.info(res.data)

--- a/User.ts
+++ b/User.ts
@@ -25,7 +25,6 @@ export default class User implements IUser {
     async loadRoles() : Promise<void> {
 
         // TODO: Implement logic on SC-server instead of webdav with a specific flag
-
         const res = await api({user : this}).get('/roles/user/' + this.uid);
 
         logger.info(res.data)

--- a/User.ts
+++ b/User.ts
@@ -1,5 +1,6 @@
 import {IUser} from "webdav-server/lib/user/v2/IUser";
 import api from './api';
+import logger from "./logger";
 
 export default class User implements IUser {
     uid: string;
@@ -24,6 +25,10 @@ export default class User implements IUser {
         // TODO: Implement logic on SC-server instead of webdav with a specific flag
 
         const res = await api({user : this}).get('/roles/user/' + this.uid);
+
+        // TODO: Store user permissions
+
+        logger.info(res.data)
 
         for (const role of res.data) {
             this.roles.push(role.id)

--- a/UserManager.ts
+++ b/UserManager.ts
@@ -12,6 +12,7 @@ export default class UserManager implements ITestableUserManager, IListUserManag
     users: Map<string, User>
 
     constructor() {
+        // TODO: Clear list regularly (sometimes there are 'ghost' files when changed in web client)
         this.users = new Map()
     }
 

--- a/UserManager.ts
+++ b/UserManager.ts
@@ -4,7 +4,6 @@ import {IUser} from "webdav-server/lib/user/v2/IUser";
 import User from "./User";
 import {v2 as webdav} from "webdav-server";
 import api from './api'
-import {environment} from './config/globals';
 import logger from './logger';
 
 export default class UserManager implements ITestableUserManager, IListUserManager {

--- a/WebFileSystem.ts
+++ b/WebFileSystem.ts
@@ -573,6 +573,7 @@ class WebFileSystem extends webdav.FileSystem {
 
             return null
         } else {
+            logger.info(this.resources.get(user.uid).get(path.toString()).permissions)
             return webdav.Errors.Forbidden
         }
     }

--- a/WebFileSystem.ts
+++ b/WebFileSystem.ts
@@ -138,6 +138,71 @@ class WebFileSystem extends webdav.FileSystem {
     }
 
     /*
+     * Gets permissions by path and user.
+     * ! Assumes that resource is loaded in this.resource !
+     *
+     * @param {Path} path         Path to resource
+     * @param {User} user           Current user
+     *
+     * @return {Permissions}   Permissions of resource
+     */
+    testPermission(path: Path, user: User, permission: string) : boolean {
+        return this.resourceExists(path, user) ? this.resources.get(user.uid).get(path.toString()).permissions[permission] : null
+    }
+
+    /*
+     * Tests read permission of loaded resource
+     * ! Assumes that resource is loaded in this.resource !
+     *
+     * @param {Path} path         Path to resource
+     * @param {User} user           Current user
+     *
+     * @return {boolean}   Read-permission of file
+     */
+    canRead(path: Path, user: User) : boolean {
+        return this.testPermission(path, user, 'read')
+    }
+
+    /*
+     * Tests write permission of loaded resource
+     * ! Assumes that resource is loaded in this.resource !
+     *
+     * @param {Path} path         Path to resource
+     * @param {User} user           Current user
+     *
+     * @return {boolean}   Write-permission of file
+     */
+    canWrite(path: Path, user: User) : boolean {
+        return this.testPermission(path, user, 'write')
+    }
+
+    /*
+     * Tests create permission of loaded resource
+     * ! Assumes that resource is loaded in this.resource !
+     *
+     * @param {Path} path         Path to resource
+     * @param {User} user           Current user
+     *
+     * @return {boolean}   Create-permission of file
+     */
+    canCreate(path: Path, user: User) : boolean {
+        return this.testPermission(path, user, 'create')
+    }
+
+    /*
+     * Tests delete permission of loaded resource
+     * ! Assumes that resource is loaded in this.resource !
+     *
+     * @param {Path} path         Path to resource
+     * @param {User} user           Current user
+     *
+     * @return {boolean}   Delete-permission of file
+     */
+    canDelete(path: Path, user: User) : boolean {
+        return this.testPermission(path, user, 'delete')
+    }
+
+    /*
      * Returns the owner ID of the given resource
      *
      * @param {Path} path   Path of the resource
@@ -595,9 +660,8 @@ class WebFileSystem extends webdav.FileSystem {
             return webdav.Errors.Forbidden
         }
 
-        // TODO: Only allow creating files in courses if user is not student (role id vs displayName?)
-
-        if (this.rootPath !== 'courses' || (this.rootPath === 'courses')) {
+        // TODO: This is not 100% similar to permission handling of web client and needs testing especially in root folders
+        if (!this.resources.get(user.uid).get(path.getParent().toString()).permissions || this.resources.get(user.uid).get(path.getParent().toString()).permissions.create) {
             if (type.isDirectory || ['docx', 'pptx', 'xlsx'].includes(mime.extension(mime.lookup(path.fileName())))) {
                 logger.info('Trying to create directory or ' + mime.extension(mime.lookup(path.fileName())) + '-file...')
 

--- a/WebFileSystem.ts
+++ b/WebFileSystem.ts
@@ -659,7 +659,6 @@ class WebFileSystem extends webdav.FileSystem {
             return webdav.Errors.Forbidden
         }
 
-        // TODO: This is not 100% similar to permission handling of web client and needs testing especially in root folders
         if (!this.resources.get(user.uid).get(path.getParent().toString()).permissions || this.canCreate(path.getParent(), user)) {
             if (type.isDirectory || ['docx', 'pptx', 'xlsx'].includes(mime.extension(mime.lookup(path.fileName())))) {
                 const owner = this.getOwnerID(path, user)

--- a/WebFileSystem.ts
+++ b/WebFileSystem.ts
@@ -105,7 +105,7 @@ class WebFileSystem extends webdav.FileSystem {
             const res = await api({user}).get(url, {params: qs})
 
             const data = res.data
-            
+
             // TODO: make this look fancy :)
             let adder
             if (this.rootPath === 'shared'){
@@ -122,7 +122,7 @@ class WebFileSystem extends webdav.FileSystem {
             for (const resource of data.data) {
                 adder(new Path([resource.name]), user, resource)
             }
-            
+
 
             return data['data'].map((resource) => resource.name)
         }
@@ -329,7 +329,7 @@ class WebFileSystem extends webdav.FileSystem {
         const res = await api({user}).get('/fileStorage/signedUrl?file=' + this.resources.get(user.uid).get(path.toString()).id);
 
         const data = res.data;
-        
+
         return data.url;
     }
 
@@ -502,7 +502,7 @@ class WebFileSystem extends webdav.FileSystem {
             }
 
             const res = await api({user , json: true}).post('/fileStorage' + (type.isDirectory ? '/directories' : '/files/new'), body);
-            
+
             const data = res.data;
 
             logger.info(data)
@@ -558,11 +558,13 @@ class WebFileSystem extends webdav.FileSystem {
      * @return {Promise<Error>}   Error or null depending on success of deletion
      */
     async deleteResource (path: Path, user: User) : Promise<Error> {
+        // TODO: Check inconsistencies with web client
+
         if (this.resources.get(user.uid).get(path.toString()).permissions?.delete) {
             const type: webdav.ResourceType = this.resources.get(user.uid).get(path.toString()).type
 
             const res = await api({user}).delete('/fileStorage' + (type.isDirectory ? '/directories?_id=' : '?_id=') + this.resources.get(user.uid).get(path.toString()).id);
- 
+
             const data = res.data;
 
             logger.info(data)
@@ -743,7 +745,7 @@ class WebFileSystem extends webdav.FileSystem {
      */
     async moveResource(resourceID: string, newParentID: string, user: User) : Promise<any> {
         return await api({user, json: true}).patch(
-            `/fileStorage/${resourceID}`, 
+            `/fileStorage/${resourceID}`,
             {parent: newParentID}
             ).then(() => null).catch(() => {
                 logger.error('File at moveResource() could not be moved', user.uid,resourceID,newParentID);

--- a/WebFileSystem.ts
+++ b/WebFileSystem.ts
@@ -595,9 +595,9 @@ class WebFileSystem extends webdav.FileSystem {
             return webdav.Errors.Forbidden
         }
 
-        // TODO: This doesn't seem to match with the way the web client checks create permission
+        // TODO: Only allow creating files in courses if user is not student (role id vs displayName?)
 
-        if (!this.resources.get(user.uid).get(path.getParent().toString()).permissions || this.resources.get(user.uid).get(path.getParent().toString()).permissions.create) {
+        if (this.rootPath !== 'courses' || (this.rootPath === 'courses')) {
             if (type.isDirectory || ['docx', 'pptx', 'xlsx'].includes(mime.extension(mime.lookup(path.fileName())))) {
                 logger.info('Trying to create directory or ' + mime.extension(mime.lookup(path.fileName())) + '-file...')
 

--- a/WebFileSystem.ts
+++ b/WebFileSystem.ts
@@ -680,7 +680,7 @@ class WebFileSystem extends webdav.FileSystem {
                 logger.info(data)
 
                 if (data._id) {
-                    await this.addFileToResources(path, user, data)
+                    this.addFileToResources(path, user, data)
                 } else {
                     logger.error(webdav.Errors.Forbidden.message)
                     return webdav.Errors.Forbidden
@@ -693,7 +693,7 @@ class WebFileSystem extends webdav.FileSystem {
                 logger.info(file)
 
                 if (file._id) {
-                    await this.addFileToResources(path, user, file)
+                    this.addFileToResources(path, user, file)
                 } else {
                     logger.error(webdav.Errors.Forbidden.message)
                     return webdav.Errors.Forbidden
@@ -749,8 +749,6 @@ class WebFileSystem extends webdav.FileSystem {
      */
     async deleteResource (path: Path, user: User) : Promise<Error> {
         // Web Client checks user permission instead of file permission, but SC-Server checks specific permission
-        logger.info('FILE_DELETE: ' + user.permissions.includes('FILE_DELETE'))
-        logger.info('resource permission: ' + this.canDelete(path, user))
         // if (this.canDelete(path, user)) {
         if (user.permissions.includes('FILE_DELETE')) {
             const type: webdav.ResourceType = this.resources.get(user.uid).get(path.toString()).type
@@ -895,7 +893,7 @@ class WebFileSystem extends webdav.FileSystem {
                     logger.info(file)
 
                     if (file._id) {
-                        await this.addFileToResources(path, user, file)
+                        this.addFileToResources(path, user, file)
                     } else {
                         logger.error(`WebFileSystem.processStream.file._id.false: ${webdav.Errors.Forbidden.message} uid: ${user.uid}`)
                     }
@@ -926,7 +924,6 @@ class WebFileSystem extends webdav.FileSystem {
             this.createUserFileSystem(user.uid)
 
             if (this.resourceExists(path, user)) {
-                logger.info('resource.permission.write: ' + this.canWrite(path, user))
                 if (this.canWrite(path, user)) {
                     callback(null, await this.processStream(path, user))
                 } else {

--- a/WebFileSystem.ts
+++ b/WebFileSystem.ts
@@ -125,8 +125,7 @@ class WebFileSystem extends webdav.FileSystem {
     }
 
     /*
-     * Gets ID by path and user.
-     * ! Assumes that resource is loaded in this.resource !
+     * Gets ID by path and user and returns null if resource not loaded
      *
      * @param {Path} path         Path to resource
      * @param {User} user           Current user
@@ -138,8 +137,7 @@ class WebFileSystem extends webdav.FileSystem {
     }
 
     /*
-     * Gets permissions by path and user.
-     * ! Assumes that resource is loaded in this.resource !
+     * Gets permissions by path and user and returns null if resource not loaded
      *
      * @param {Path} path         Path to resource
      * @param {User} user           Current user
@@ -151,8 +149,7 @@ class WebFileSystem extends webdav.FileSystem {
     }
 
     /*
-     * Tests read permission of loaded resource
-     * ! Assumes that resource is loaded in this.resource !
+     * Tests read permission of resource and returns null if resource not loaded
      *
      * @param {Path} path         Path to resource
      * @param {User} user           Current user
@@ -164,8 +161,7 @@ class WebFileSystem extends webdav.FileSystem {
     }
 
     /*
-     * Tests write permission of loaded resource
-     * ! Assumes that resource is loaded in this.resource !
+     * Tests write permission of resource and returns null if resource not loaded
      *
      * @param {Path} path         Path to resource
      * @param {User} user           Current user
@@ -177,8 +173,7 @@ class WebFileSystem extends webdav.FileSystem {
     }
 
     /*
-     * Tests create permission of loaded resource
-     * ! Assumes that resource is loaded in this.resource !
+     * Tests create permission of resource and returns null if resource not loaded
      *
      * @param {Path} path         Path to resource
      * @param {User} user           Current user
@@ -190,8 +185,7 @@ class WebFileSystem extends webdav.FileSystem {
     }
 
     /*
-     * Tests delete permission of loaded resource
-     * ! Assumes that resource is loaded in this.resource !
+     * Tests delete permission of resource and returns null if resource not loaded
      *
      * @param {Path} path         Path to resource
      * @param {User} user           Current user
@@ -309,12 +303,11 @@ class WebFileSystem extends webdav.FileSystem {
                 if (this.rootPath === 'teams') {
                     const res = await api({user}).get('/teams/' + resource._id)
 
-                    logger.info(res.data)
+                    logger.debug(res.data)
 
                     this.resources.get(user.uid).get('/' + resource.name).role = res.data.user.role
                 }
             }
-
 
             return data['data'].map((resource) => resource.name)
         } else {
@@ -375,7 +368,7 @@ class WebFileSystem extends webdav.FileSystem {
         if (this.rootPath === 'teams') {
             const teamRes = await api({user}).get('teams/' + owner)
 
-            logger.info(teamRes.data)
+            logger.debug(teamRes.data)
         }
 
         const resources = []
@@ -690,7 +683,7 @@ class WebFileSystem extends webdav.FileSystem {
                 await this.writeToSignedUrl(data.url, data.header, [])
                 const file = await this.writeToFileStorage(path, user, data.header, [])
 
-                logger.info(file)
+                logger.debug(file)
 
                 if (file._id) {
                     this.addFileToResources(path, user, file)

--- a/WebFileSystem.ts
+++ b/WebFileSystem.ts
@@ -671,7 +671,7 @@ logger.info(data)
      * @return {Promise<Error>}   Error or null depending on success of deletion
      */
     async deleteResource (path: Path, user: User) : Promise<Error> {
-        // TODO: Check inconsistencies with web client
+        // TODO: Web Client checks user permissions instead of file permissions
 
         if (this.resources.get(user.uid).get(path.toString()).permissions?.delete) {
             const type: webdav.ResourceType = this.resources.get(user.uid).get(path.toString()).type

--- a/WebFileSystem.ts
+++ b/WebFileSystem.ts
@@ -922,14 +922,16 @@ class WebFileSystem extends webdav.FileSystem {
                 const toParentID: string = this.getID(pathTo.getParent(), user);
 
                 if(!this.validFileName(pathTo.fileName())){
-                logger.warn(`WebFileSystem._move : Resoucename ${pathTo.fileName()} not allowed. pathFrom: ${pathFrom}`)
-                callback(webdav.Errors.Forbidden)
-            } else if (this.resourceExists(pathTo, user)){
-                logger.warn(`WebFileSystem._move: Resource already exists at give path. pathTo: ${pathTo.toString()} uid: ${user.uid}`)
-                callback(webdav.Errors.Forbidden)
-            }callback(await this.moveResource(fileID, toParentID, user, pathFrom, pathTo))
+                    logger.warn(`WebFileSystem._move : Resoucename ${pathTo.fileName()} not allowed. pathFrom: ${pathFrom}`)
+                    callback(webdav.Errors.Forbidden)
+                } else if (this.resourceExists(pathTo, user)){
+                    logger.warn(`WebFileSystem._move: Resource already exists at give path. pathTo: ${pathTo.toString()} uid: ${user.uid}`)
+                    callback(webdav.Errors.Forbidden)
+                } else {
+                    callback(await this.moveResource(fileID, toParentID, user, pathFrom, pathTo))
+                }
             } else {
-                logger.error('WebFileSystem._move.owner.false : ' + webdav.Errors.Forbidden.message + ' uid: ' + user.uid)
+                logger.error(`WebFileSystem._move.owner.false : ${webdav.Errors.Forbidden.message} uid: ${user.uid}`)
                 callback(webdav.Errors.Forbidden)
             }
         } else {
@@ -949,8 +951,7 @@ class WebFileSystem extends webdav.FileSystem {
      */
     async renameResource (path: Path, user: User, newName: string) : Promise<Error> {
         if (this.resources.get(user.uid).get(path.toString()).permissions.write) {
-
-            let newPath = new Path( path.getParent().toString()+'/'+newName)
+            const newPath = path.getParent().getChildPath(newName)
             if(this.resourceExists(newPath, user)){
                 logger.warn(`WebFileSystem.renameResource: Resource already exists at give path. path: ${path.toString()} newName: ${newName}`)
                 return webdav.Errors.Forbidden
@@ -987,8 +988,6 @@ class WebFileSystem extends webdav.FileSystem {
             this.createUserFileSystem(user.uid)
 
             if (this.resourceExists(pathFrom, user)) {
-                // TODO: Check permission (not happening in web client but would be best to check if owner)
-
                 callback(await this.renameResource(pathFrom, user, newName))
             } else {
                 if (await this.loadPath(pathFrom, user)) {

--- a/WebFileSystem.ts
+++ b/WebFileSystem.ts
@@ -509,7 +509,7 @@ class WebFileSystem extends webdav.FileSystem {
 
             this.createUserFileSystem(user.uid)
 
-            if (this.resources.get(user.uid).get(path.toString()).permissions.read) {
+            if (this.canRead(path, user)) {
                 const url = await this.retrieveSignedUrl(path, user)
 
                 logger.info("Signed URL: " + url)
@@ -661,7 +661,7 @@ class WebFileSystem extends webdav.FileSystem {
         }
 
         // TODO: This is not 100% similar to permission handling of web client and needs testing especially in root folders
-        if (!this.resources.get(user.uid).get(path.getParent().toString()).permissions || this.resources.get(user.uid).get(path.getParent().toString()).permissions.create) {
+        if (!this.resources.get(user.uid).get(path.getParent().toString()).permissions || this.canCreate(path.getParent(), user)) {
             if (type.isDirectory || ['docx', 'pptx', 'xlsx'].includes(mime.extension(mime.lookup(path.fileName())))) {
                 logger.info('Trying to create directory or ' + mime.extension(mime.lookup(path.fileName())) + '-file...')
 
@@ -757,8 +757,8 @@ class WebFileSystem extends webdav.FileSystem {
 
         // Web Client checks user permission instead of file permission
         logger.info('FILE_DELETE: ' + user.permissions.includes('FILE_DELETE'))
-        logger.info('resource permission: ' + this.resources.get(user.uid).get(path.toString()).permissions?.delete)
-        // if (this.resources.get(user.uid).get(path.toString()).permissions?.delete) {
+        logger.info('resource permission: ' + this.canDelete(path, user))
+        // if (this.canDelete(path, user)) {
         if (user.permissions.includes('FILE_DELETE')) {
             const type: webdav.ResourceType = this.resources.get(user.uid).get(path.toString()).type
 
@@ -918,8 +918,8 @@ class WebFileSystem extends webdav.FileSystem {
             this.createUserFileSystem(user.uid)
 
             if (this.resourceExists(path, user)) {
-                logger.info('resource.permission.write: ' + this.resources.get(user.uid).get(path.toString()).permissions?.write)
-                if (this.resources.get(user.uid).get(path.toString()).permissions?.write) {
+                logger.info('resource.permission.write: ' + this.canWrite(path, user))
+                if (this.canWrite(path, user)) {
                     callback(null, await this.processStream(path, user))
                 } else {
                     logger.error('Writing not allowed!')
@@ -1014,7 +1014,7 @@ class WebFileSystem extends webdav.FileSystem {
      * @return {Promise<Error>}   Error or null depending on success of renaming
      */
     async renameResource (path: Path, user: User, newName: string) : Promise<Error> {
-        if (this.resources.get(user.uid).get(path.toString()).permissions.write) {
+        if (this.canWrite(path, user)) {
             const newPath = path.getParent().getChildPath(newName)
             if(this.resourceExists(newPath, user)){
                 logger.warn(`WebFileSystem.renameResource: Resource already exists at give path. path: ${path.toString()} newName: ${newName}`)

--- a/WebFileSystem.ts
+++ b/WebFileSystem.ts
@@ -241,7 +241,7 @@ class WebFileSystem extends webdav.FileSystem {
      *
      * @return {Boolean}    true if fileName is valid, false else
      */
-    validFileName(name: string): Boolean{
+    validFileName(name: string): boolean {
         return !name.match(/[#%^[\],<>?/|~{}]+/)
     }
     /*
@@ -656,7 +656,7 @@ class WebFileSystem extends webdav.FileSystem {
             logger.info(`Resource ${path} already exists.`)
             return webdav.Errors.ResourceAlreadyExists
         } else if (!this.validFileName(path.fileName())){
-            logger.info(`Resourcename ${path.fileName()} not allowed.`)
+            logger.info(`Name ${path.fileName()} not allowed.`)
             return webdav.Errors.Forbidden
         }
 
@@ -986,7 +986,7 @@ class WebFileSystem extends webdav.FileSystem {
                 const toParentID: string = this.getID(pathTo.getParent(), user);
 
                 if(!this.validFileName(pathTo.fileName())){
-                    logger.warn(`WebFileSystem._move : Resoucename ${pathTo.fileName()} not allowed. pathFrom: ${pathFrom}`)
+                    logger.warn(`WebFileSystem._move : Name ${pathTo.fileName()} not allowed. pathFrom: ${pathFrom}`)
                     callback(webdav.Errors.Forbidden)
                 } else if (this.resourceExists(pathTo, user)){
                     logger.warn(`WebFileSystem._move: Resource already exists at give path. pathTo: ${pathTo.toString()} uid: ${user.uid}`)
@@ -1021,7 +1021,7 @@ class WebFileSystem extends webdav.FileSystem {
                 return webdav.Errors.Forbidden
             }
             if(!this.validFileName(newName)){
-                logger.warn(`Resourcename: ${newName} not allowed.`)
+                logger.warn(`Name ${newName} not allowed.`)
                 return webdav.Errors.Forbidden
             }
             const type: webdav.ResourceType = this.resources.get(user.uid).get(path.toString()).type


### PR DESCRIPTION
While testing the permission functionalities I noticed some things which behaved differently from the SC web-client concerning the permission handling (for example deleting resources)